### PR TITLE
fix button cannot be a descendant of button error

### DIFF
--- a/src/components/ChainSelector.tsx
+++ b/src/components/ChainSelector.tsx
@@ -26,7 +26,7 @@ export function ChainSelector() {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="inline-flex items-center gap-1">
+      <DropdownMenuTrigger asChild className="inline-flex items-center gap-1">
         {currentChainBadge}
       </DropdownMenuTrigger>
       <DropdownMenuContent>


### PR DESCRIPTION
Great work on this starter!

This patch fixes an error that showed up in the console!
![image](https://github.com/user-attachments/assets/72de3c29-0b1e-4b48-9f6b-6fb949064772)
